### PR TITLE
Updated bulk price update docs to more accurate notation

### DIFF
--- a/docs/price.md
+++ b/docs/price.md
@@ -66,21 +66,21 @@ $price = $client->bulk([
             ],
             [
                 'itemIdentifier' => [
-                    'sku' => '1131270'
+                    'sku' => '1131271'
                 ],
                 'pricingList' => [
                     'pricing' => [
                         'currentPrice' => [
                             'value' => [
                                 'currency' => 'USD',
-                                'amount' => '4.00',
+                                'amount' => '3.00',
                             ],
                         ],
                         'currentPriceType' => 'BASE',
                         'comparisonPrice' => [
                             'value' => [
                                 'currency' => 'USD',
-                                'amount' => '5.99',
+                                'amount' => '4.99',
                             ],
                         ],
                         'priceDisplayCode' => [

--- a/docs/price.md
+++ b/docs/price.md
@@ -37,30 +37,59 @@ $price = $client->bulk([
             'version' => '1.5',
         ],
         'Price' => [
-            'itemIdentifier' => [
-                'sku' => '1131270'
+            [
+                'itemIdentifier' => [
+                    'sku' => '1131270'
+                ],
+                'pricingList' => [
+                    'pricing' => [
+                        'currentPrice' => [
+                            'value' => [
+                                'currency' => 'USD',
+                                'amount' => '4.00',
+                            ],
+                        ],
+                        'currentPriceType' => 'BASE',
+                        'comparisonPrice' => [
+                            'value' => [
+                                'currency' => 'USD',
+                                'amount' => '5.99',
+                            ],
+                        ],
+                        'priceDisplayCode' => [
+                            'submapType' => 'CHECKOUT',
+                        ],
+                        'effectiveDate' => '2016-07-02T12:38:43-04:00',
+                        'expirationDate' => '2016-08-02T12:38:43-04:00',
+                    ],
+                ],
             ],
-            'pricingList' => [
-                'pricing' => [
-                    'currentPrice' => [
-                        'value' => [
-                            'currency' => 'USD',
-                            'amount' => '4.00',
+            [
+                'itemIdentifier' => [
+                    'sku' => '1131270'
+                ],
+                'pricingList' => [
+                    'pricing' => [
+                        'currentPrice' => [
+                            'value' => [
+                                'currency' => 'USD',
+                                'amount' => '4.00',
+                            ],
                         ],
-                    ],
-                    'currentPriceType' => 'BASE',
-                    'comparisonPrice' => [
-                        'value' => [
-                            'currency' => 'USD',
-                            'amount' => '5.99',
+                        'currentPriceType' => 'BASE',
+                        'comparisonPrice' => [
+                            'value' => [
+                                'currency' => 'USD',
+                                'amount' => '5.99',
+                            ],
                         ],
+                        'priceDisplayCode' => [
+                            'submapType' => 'CHECKOUT',
+                        ],
+                        'effectiveDate' => '2016-07-02T12:38:43-04:00',
+                        'expirationDate' => '2016-08-02T12:38:43-04:00',
                     ],
-                    'priceDisplayCode' => [
-                        'submapType' => 'CHECKOUT',
-                    ],
-                    'effectiveDate' => '2016-07-02T12:38:43-04:00',
-                    'expirationDate' => '2016-08-02T12:38:43-04:00',
-                ]
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
The array notation in [Bulk update Item Prices](https://github.com/fillup/walmart-partner-api-sdk-php/blob/develop/docs/price.md#bulk-update-item-prices) implied that only one price can be uploaded. I changed the price array to contain multiple arrays to imply that multiple prices can be updated at once.